### PR TITLE
Have wheresRstudio() look in /Applications/ on OS X

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -186,7 +186,7 @@ wheresRstudio <-
 function() {
     myPaths <- c("rstudio",  "~/.cabal/bin/rstudio", 
         "~/Library/Haskell/bin/rstudio", "C:\\PROGRA~1\\RStudio\\bin\\rstudio.exe",
-        "C:\\RStudio\\bin\\rstudio.exe")
+        "C:\\RStudio\\bin\\rstudio.exe", "/Applications/RStudio.app/Contents/MacOS/RStudio")
     panloc <- Sys.which(myPaths)
     temp <- panloc[panloc != ""]
     if (identical(names(temp), character(0))) {


### PR DESCRIPTION
Add `"/Applications/RStudio.app/Contents/MacOS/RStudio"` to the `myPaths` search for `wheresRstudio()`. This is the standard location for Rstudio.app to be installed on OS X. I've tested this on my system, and the location of Rstudio is correctly located.

``` R
R version 3.0.1 (2013-05-16)
Platform: x86_64-apple-darwin12.4.0 (64-bit)

locale:
[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8

attached base packages:
[1] stats     graphics  grDevices utils     datasets 
[6] methods   base     

other attached packages:
[1] fortunes_1.5-0  devtools_1.3.99

loaded via a namespace (and not attached):
[1] digest_0.6.3   evaluate_0.4.7 httr_0.2      
[4] memoise_0.1    parallel_3.0.1 RCurl_1.95-4.1
[7] stringr_0.6.2  tools_3.0.1    whisker_0.3-2 
```
